### PR TITLE
Make it possible to use minitest-bender with rake -rminitest/bender test

### DIFF
--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'forwardable'
 
 module MinitestBender
@@ -17,7 +18,7 @@ module MinitestBender
             minitest_result.klass
           else
             minitest_result.class.name
-          end.gsub('::', ' > ')
+          end.gsub('::', ' ▸ ')
       end
 
       def header

--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module MinitestBender
   module Results
     class Base

--- a/lib/minitest/bender_plugin.rb
+++ b/lib/minitest/bender_plugin.rb
@@ -1,5 +1,6 @@
 module Minitest
   def self.plugin_bender_init(options)
+    return unless defined? Bender
     Minitest.reporter.reporters.clear
     Minitest.reporter << Bender.new(options.fetch(:io, $stdout), options)
   end


### PR DESCRIPTION
Hello!

I was evaluating different minitest reporters and I liked this one, as I thought it could be a good basis to implement some of my own ideas about the "ideal test reporter" ;-)  So nice work, thanks!

However, there were a few glitches when running v0.0.3 as is, which I corrected here.
The errors fixed here don't surface when minitest-bender is installed as a gem, but rather when you activate it via -I/-r.

I used it that way at first because once you install minitest-bender, you won't be able to use other reporters. Better integration with other reporters will be the topic for the next pull request, nevertheless, these changes won't hurt.  