### PR TITLE
Minitest reporters compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,6 @@ All notable changes to this project will be documented in this file. This projec
 * Initial release
 
 [Semver]: http://semver.org
-[Unreleased]: https://github.com/eugeniobruno/minitest-bender/compare/v0.0.2...HEAD
+[Unreleased]: https://github.com/eugeniobruno/minitest-bender/compare/v0.0.3...HEAD
 [0.0.3]: https://github.com/eugeniobruno/minitest-bender/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/eugeniobruno/minitest-bender/compare/v0.0.1...v0.0.2

--- a/README.md
+++ b/README.md
@@ -28,9 +28,19 @@ Require this plugin right after Minitest:
 ```ruby
 require 'minitest/autorun'
 require 'minitest/bender'
+Minitest::Bender.enable!
 ```
 
 That's it! The next time you run your tests, a new report format will be used instead of the default one.
+
+Instead of `Minitest::Bender.enable!`, you can also specify the `--bender` test option, e.g.
+
+    $ rake test TESTOPTS=--bender
+
+If you already have [minitest-reporters](https://github.com/kern/minitest-reporters) installed and activated, you can select the `BenderReporter` as (one of the) reporters:
+
+    $ MINITEST_REPORTER=BenderReporter,HtmlReporter rake test
+
 
 ## Features
 

--- a/lib/minitest-bender/version.rb
+++ b/lib/minitest-bender/version.rb
@@ -1,3 +1,3 @@
 module MinitestBender
-  VERSION = '0.0.3'.freeze
+  VERSION = '0.1.0'.freeze
 end

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -3,7 +3,11 @@ require 'minitest_bender'
 
 module Minitest
   class Bender < AbstractReporter
-    attr_reader :io, :options, :previous_context, :results, :started_at
+    def self.enable!; @@is_enabled = true; end
+    def self.enabled?; @@is_enabled ||= false; end
+
+    attr_accessor :io, :options
+    attr_reader :previous_context, :results, :started_at
 
     def initialize(io, options = {})
       @io = io
@@ -153,6 +157,36 @@ module Minitest
 
     def formatted_slowness_podium_label
       "  #{Colorin.grey_700('SLOWNESS PODIUM').bold.underline}"
+    end
+  end
+
+  ##
+  # Compatibility with
+  # [minitest-reporters](https://github.com/kern/minitest-reporters)
+  #
+  # Given:
+  #
+  # ```
+  # require 'minitest/reporters'
+  # Minitest::Reporters.use!
+  # ```
+  #
+  # Bender can be selected with:
+  #
+  # ```
+  # MINITEST_REPORTER=BenderReporter rake test
+  # ```
+
+  module Reporters
+    class BenderReporter < Minitest::Bender
+      def initialize(options = {})
+        super(options.fetch(:io, $stdout), options)
+      end
+      def add_defaults(options)
+        @options = options
+      end
+      def before_test(_test_cls); end
+      def after_test(_test_cls); end
     end
   end
 end

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -3,11 +3,16 @@ require 'minitest_bender'
 
 module Minitest
   class Bender < AbstractReporter
-    def self.enable!; @@is_enabled = true; end
-    def self.enabled?; @@is_enabled ||= false; end
-
     attr_accessor :io, :options
     attr_reader :previous_context, :results, :started_at
+
+    def self.enable!
+      @@is_enabled = true
+    end
+
+    def self.enabled?
+      @@is_enabled ||= false
+    end
 
     def initialize(io, options = {})
       @io = io
@@ -182,10 +187,13 @@ module Minitest
       def initialize(options = {})
         super(options.fetch(:io, $stdout), options)
       end
+
       def add_defaults(options)
         @options = options
       end
+
       def before_test(_test_cls); end
+
       def after_test(_test_cls); end
     end
   end

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -188,8 +188,8 @@ module Minitest
         super(options.fetch(:io, $stdout), options)
       end
 
-      def add_defaults(options)
-        @options = options
+      def add_defaults(defaults)
+        @options = defaults.merge(options)
       end
 
       def before_test(_test_cls); end

--- a/lib/minitest/bender_plugin.rb
+++ b/lib/minitest/bender_plugin.rb
@@ -1,8 +1,15 @@
+require 'minitest/bender'
+
 module Minitest
   def self.plugin_bender_init(options)
+    return unless Bender.enabled?
     Minitest.reporter.reporters.clear
     Minitest.reporter << Bender.new(options.fetch(:io, $stdout), options)
   end
 
-  def self.plugin_bender_options(_opts, _options); end
+  def self.plugin_bender_options(opts, _options)
+    opts.on '--bender', 'Use Minitest::Bender test reporter' do
+      Bender.enable!
+    end
+  end
 end


### PR DESCRIPTION
Currently minitest-bender "takes over", when installed. You can't switch to another reporter, say to get some HTML output or XML, or whatever else.

A way to do an "opt-in" would be better. The first idea was to add support for a `--bender` option, to activate the reporter only when this option is given to the TESTOPTS.

The other idea was to make it possible to play along with the [kern/minitest-reporters](https://github.com/kern/minitest-reporters) gem, which introduces a nice way to activate different reporters at once.
