### PR TITLE
Sorted test results

### DIFF
--- a/lib/minitest-bender/colorizer.rb
+++ b/lib/minitest-bender/colorizer.rb
@@ -32,7 +32,7 @@ module MinitestBender
       end
 
       def windows?
-        @windows ||= RbConfig::CONFIG['host_os'] =~ /mswin/
+        @windows ||= RbConfig::CONFIG['host_os'] =~ /mswin|mingw32/
       end
     end
   end

--- a/lib/minitest-bender/colorizer.rb
+++ b/lib/minitest-bender/colorizer.rb
@@ -1,0 +1,39 @@
+require 'rbconfig'
+
+module MinitestBender
+  class Colorizer
+    FALLBACK_COLORS = {
+      red_500: :red,
+      green_500: :green,
+      amber_300: :yellow,
+      blue_a700: :blue,
+      purple_400: :magenta,
+      cyan_300: :cyan
+    }.freeze
+
+    class << self
+      def colorize(color, string)
+        if fallback?
+          fallback_color = FALLBACK_COLORS[color]
+          if fallback_color.nil?
+            Colorin.new(string)
+          else
+            Colorin.public_send(fallback_color, string)
+          end
+        else
+          Colorin.public_send(color, string)
+        end
+      end
+
+      private
+
+      def fallback?
+        windows?
+      end
+
+      def windows?
+        @windows ||= RbConfig::CONFIG['host_os'] =~ /mswin/
+      end
+    end
+  end
+end

--- a/lib/minitest-bender/result_factory.rb
+++ b/lib/minitest-bender/result_factory.rb
@@ -7,7 +7,7 @@ module MinitestBender
       result_number = number(minitest_result)
       result_name = name(minitest_result)
       if result_number.empty?
-        Results::Test.new(minitest_result, result_name, result_name)
+        Results::Test.new(minitest_result, result_name)
       else
         Results::Expectation.new(minitest_result, result_number, result_name)
       end

--- a/lib/minitest-bender/result_factory.rb
+++ b/lib/minitest-bender/result_factory.rb
@@ -7,7 +7,7 @@ module MinitestBender
       result_number = number(minitest_result)
       result_name = name(minitest_result)
       if result_number.empty?
-        Results::Test.new(minitest_result, result_name)
+        Results::Test.new(minitest_result, result_name, result_name)
       else
         Results::Expectation.new(minitest_result, result_number, result_name)
       end

--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -4,13 +4,10 @@ module MinitestBender
       extend Forwardable
       def_delegators :@minitest_result, :passed?, :skipped?, :assertions, :failures, :time
 
-      def initialize(minitest_result, rank)
+      def initialize(minitest_result)
         @minitest_result = minitest_result
-        @rank = rank
         @state = MinitestBender.states.fetch(minitest_result.result_code)
       end
-
-      attr_reader :rank, :state
 
       def context
         @context ||=
@@ -26,7 +23,7 @@ module MinitestBender
       end
 
       def compact
-        @state.tag
+        state.tag
       end
 
       def details_header(number)

--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -4,10 +4,13 @@ module MinitestBender
       extend Forwardable
       def_delegators :@minitest_result, :passed?, :skipped?, :assertions, :failures, :time
 
-      def initialize(minitest_result)
+      def initialize(minitest_result, rank)
         @minitest_result = minitest_result
+        @rank = rank
         @state = MinitestBender.states.fetch(minitest_result.result_code)
       end
+
+      attr_reader :rank, :state
 
       def context
         @context ||=
@@ -20,6 +23,10 @@ module MinitestBender
 
       def header
         Colorin.white("• #{context}").bold
+      end
+
+      def compact
+        @state.tag
       end
 
       def details_header(number)

--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 require 'forwardable'
 
 module MinitestBender

--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -6,10 +6,12 @@ module MinitestBender
     class Base
       extend Forwardable
       def_delegators :@minitest_result, :passed?, :skipped?, :assertions, :failures, :time
+      attr_reader :state, :execution_order
 
       def initialize(minitest_result)
         @minitest_result = minitest_result
         @state = MinitestBender.states.fetch(minitest_result.result_code)
+        @execution_order = @state.incr
       end
 
       def context
@@ -48,7 +50,7 @@ module MinitestBender
 
       private
 
-      attr_reader :minitest_result, :state
+      attr_reader :minitest_result
 
       def formatted_label
         "    #{state.formatted_label}"

--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -22,8 +22,8 @@ module MinitestBender
         Colorin.white("• #{context}").bold
       end
 
-      def compact
-        state.tag
+      def to_icon
+        state.colored_icon
       end
 
       def details_header(number)

--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -19,7 +19,7 @@ module MinitestBender
       end
 
       def header
-        Colorin.white("• #{context}").bold
+        Colorizer.colorize(:white, "• #{context}").bold
       end
 
       def to_icon
@@ -27,12 +27,12 @@ module MinitestBender
       end
 
       def details_header(number)
-        "    #{number}#{Colorin.white(context)} > #{name}"
+        "    #{number}#{Colorizer.colorize(:white, context)} > #{name}"
       end
 
       def rerun_line(padding)
         unformatted = "Rerun: #{rerun_command}"
-        "#{padding}#{Colorin.blue_a700(unformatted)}"
+        "#{padding}#{Colorizer.colorize(:blue_a700, unformatted)}"
       end
 
       def state?(some_state)
@@ -40,7 +40,7 @@ module MinitestBender
       end
 
       def line_for_slowness_podium
-        "#{formatted_time} #{Colorin.white(context)} > #{name}"
+        "#{formatted_time} #{Colorizer.colorize(:white, context)} > #{name}"
       end
 
       private
@@ -70,7 +70,7 @@ module MinitestBender
           else
             sprintf('%.0fs', time_in_s)
           end
-        Colorin.grey_700(time_with_unit.rjust(6))
+        Colorizer.colorize(:grey_700, time_with_unit.rjust(6))
       end
 
       def rerun_command

--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -8,6 +8,9 @@ module MinitestBender
       def_delegators :@minitest_result, :passed?, :skipped?, :assertions, :failures, :time
       attr_reader :state, :execution_order
 
+      CLASS_SEP = ' ▸ '
+      NAME_SEP =  ' ◆ '
+
       def initialize(minitest_result)
         @minitest_result = minitest_result
         @state = MinitestBender.states.fetch(minitest_result.result_code)
@@ -20,7 +23,7 @@ module MinitestBender
             minitest_result.klass
           else
             minitest_result.class.name
-          end.gsub('::', ' ▸ ')
+          end.gsub('::', CLASS_SEP)
       end
 
       def header
@@ -32,7 +35,7 @@ module MinitestBender
       end
 
       def details_header(number)
-        "    #{number}#{Colorizer.colorize(:white, context)} > #{name}"
+        "    #{number}#{Colorizer.colorize(:white, context)}#{NAME_SEP}#{name}"
       end
 
       def rerun_line(padding)
@@ -45,7 +48,7 @@ module MinitestBender
       end
 
       def line_for_slowness_podium
-        "#{formatted_time} #{Colorizer.colorize(:white, context)} > #{name}"
+        "#{formatted_time} #{Colorizer.colorize(:white, context)}#{NAME_SEP}#{name}"
       end
 
       private

--- a/lib/minitest-bender/results/expectation.rb
+++ b/lib/minitest-bender/results/expectation.rb
@@ -2,7 +2,7 @@ module MinitestBender
   module Results
     class Expectation < Base
       def initialize(minitest_result, number, name)
-        super(minitest_result)
+        super(minitest_result, number.to_i)
         @number = number
         @name = name
       end

--- a/lib/minitest-bender/results/expectation.rb
+++ b/lib/minitest-bender/results/expectation.rb
@@ -2,13 +2,17 @@ module MinitestBender
   module Results
     class Expectation < Base
       def initialize(minitest_result, number, name)
-        super(minitest_result, number.to_i)
+        super(minitest_result)
         @number = number
         @name = name
       end
 
       def line_to_report
         "#{formatted_label}#{formatted_time} #{formatted_number} #{name} #{formatted_message}"
+      end
+
+      def sort_key
+        @sort_key ||= number.to_i
       end
 
       private

--- a/lib/minitest-bender/results/expectation.rb
+++ b/lib/minitest-bender/results/expectation.rb
@@ -20,7 +20,7 @@ module MinitestBender
       attr_reader :number, :name
 
       def formatted_number
-        "#{Colorin.brown_400(number)} "
+        "#{Colorizer.colorize(:brown_400, number)} "
       end
 
       def name_for_rerun_command

--- a/lib/minitest-bender/results/test.rb
+++ b/lib/minitest-bender/results/test.rb
@@ -2,7 +2,7 @@ module MinitestBender
   module Results
     class Test < Base
       def initialize(minitest_result, raw_name)
-        super(minitest_result)
+        super(minitest_result, raw_name)
         @raw_name = raw_name
       end
 

--- a/lib/minitest-bender/results/test.rb
+++ b/lib/minitest-bender/results/test.rb
@@ -2,7 +2,7 @@ module MinitestBender
   module Results
     class Test < Base
       def initialize(minitest_result, raw_name)
-        super(minitest_result, raw_name)
+        super(minitest_result)
         @raw_name = raw_name
       end
 
@@ -12,6 +12,10 @@ module MinitestBender
 
       def line_to_report
         "#{formatted_label}#{formatted_time} #{name} #{formatted_message}"
+      end
+
+      def sort_key
+        raw_name
       end
 
       private

--- a/lib/minitest-bender/states/base.rb
+++ b/lib/minitest-bender/states/base.rb
@@ -9,8 +9,8 @@ module MinitestBender
         @formatted_group_label ||= "  #{colored(group_label).bold.underline}"
       end
 
-      def tag
-        colored(self.class::TAG)
+      def colored_icon
+        colored(icon)
       end
 
       def print_details(io, results)
@@ -48,6 +48,10 @@ module MinitestBender
 
       def group_label
         self.class::GROUP_LABEL
+      end
+
+      def icon
+        self.class::ICON
       end
 
       def colored(string)

--- a/lib/minitest-bender/states/base.rb
+++ b/lib/minitest-bender/states/base.rb
@@ -20,16 +20,20 @@ module MinitestBender
         io.puts formatted_group_label
         io.puts
         filtered_results.each_with_index do |result, i|
-          number = "#{i + 1})".ljust(4)
-          padding = ' ' * (number.size + 4)
-          io.puts(result.details_header(number))
-          do_print_details(io, result, padding)
-          io.puts
-          io.puts(result.rerun_line(padding))
+          print_detail(io, i + 1, result)
           io.puts if i < filtered_results.size - 1
         end
         io.puts
         :printed_details
+      end
+
+      def print_detail(io, i, result)
+        number = "#{i})".ljust(4)
+        padding = ' ' * (number.size + 4)
+        io.puts(result.details_header(number))
+        do_print_details(io, result, padding)
+        io.puts
+        io.puts(result.rerun_line(padding))
       end
 
       def color

--- a/lib/minitest-bender/states/base.rb
+++ b/lib/minitest-bender/states/base.rb
@@ -9,6 +9,10 @@ module MinitestBender
         @formatted_group_label ||= "  #{colored(group_label).bold.underline}"
       end
 
+      def tag
+        colored(self.class::TAG)
+      end
+
       def print_details(io, results)
         filtered_results = only_with_this_state(results)
         return :no_details if filtered_results.empty?

--- a/lib/minitest-bender/states/base.rb
+++ b/lib/minitest-bender/states/base.rb
@@ -75,7 +75,7 @@ module MinitestBender
         result.failures[0].message.split("\n").each do |line|
           io.puts "#{padding}#{colored(line)}"
         end
-        io.puts "#{padding}#{Colorizer.colorize(:brown_400, location(result))}"
+        io.puts "#{padding}#{Colorizer.colorize(:brown_400, location(result))}:"
       end
 
       def location(result)

--- a/lib/minitest-bender/states/base.rb
+++ b/lib/minitest-bender/states/base.rb
@@ -55,7 +55,7 @@ module MinitestBender
       end
 
       def colored(string)
-        Colorin.public_send(color, string)
+        Colorizer.colorize(color, string)
       end
 
       def only_with_this_state(results)
@@ -66,7 +66,7 @@ module MinitestBender
         result.failures[0].message.split("\n").each do |line|
           io.puts "#{padding}#{colored(line)}"
         end
-        io.puts "#{padding}#{Colorin.brown_400(location(result))}"
+        io.puts "#{padding}#{Colorizer.colorize(:brown_400, location(result))}"
       end
 
       def location(result)

--- a/lib/minitest-bender/states/base.rb
+++ b/lib/minitest-bender/states/base.rb
@@ -20,15 +20,15 @@ module MinitestBender
         io.puts formatted_group_label
         io.puts
         filtered_results.each_with_index do |result, i|
-          print_detail(io, i + 1, result)
+          print_detail(io, result)
           io.puts if i < filtered_results.size - 1
         end
         io.puts
         :printed_details
       end
 
-      def print_detail(io, i, result)
-        number = "#{i})".ljust(4)
+      def print_detail(io, result)
+        number = "#{result.execution_order})".ljust(4)
         padding = ' ' * (number.size + 4)
         io.puts(result.details_header(number))
         do_print_details(io, result, padding)
@@ -42,6 +42,11 @@ module MinitestBender
 
       def test_location(result)
         location(result)
+      end
+
+      def incr
+        @i ||= 0
+        @i += 1
       end
 
       private

--- a/lib/minitest-bender/states/failing.rb
+++ b/lib/minitest-bender/states/failing.rb
@@ -1,9 +1,13 @@
+# coding: utf-8
+# frozen_string_literal: true
+
 module MinitestBender
   module States
     class Failing < Base
-      COLOR = :red_500
-      LABEL = 'FAILED'.freeze
-      GROUP_LABEL = 'FAILURES'.freeze
+      COLOR = :red
+      LABEL = 'FAILED'
+      GROUP_LABEL = 'FAILURES'
+      TAG = '❌'
 
       def formatted_message(result)
         @formatted_message ||= colored(location(result))

--- a/lib/minitest-bender/states/failing.rb
+++ b/lib/minitest-bender/states/failing.rb
@@ -7,7 +7,7 @@ module MinitestBender
       COLOR = :red
       LABEL = 'FAILED'
       GROUP_LABEL = 'FAILURES'
-      ICON = '❌'
+      ICON = '✖'
 
       def formatted_message(result)
         @formatted_message ||= colored(location(result))

--- a/lib/minitest-bender/states/failing.rb
+++ b/lib/minitest-bender/states/failing.rb
@@ -4,7 +4,7 @@
 module MinitestBender
   module States
     class Failing < Base
-      COLOR = :red
+      COLOR = :red_500
       LABEL = 'FAILED'
       GROUP_LABEL = 'FAILURES'
       ICON = '✖'

--- a/lib/minitest-bender/states/failing.rb
+++ b/lib/minitest-bender/states/failing.rb
@@ -7,7 +7,7 @@ module MinitestBender
       COLOR = :red
       LABEL = 'FAILED'
       GROUP_LABEL = 'FAILURES'
-      TAG = '❌'
+      ICON = '❌'
 
       def formatted_message(result)
         @formatted_message ||= colored(location(result))

--- a/lib/minitest-bender/states/passing.rb
+++ b/lib/minitest-bender/states/passing.rb
@@ -7,7 +7,7 @@ module MinitestBender
       COLOR = :green
       LABEL = 'PASSED'
       GROUP_LABEL = 'PASSING'
-      TAG = '✔'
+      ICON = '✔'
 
       def formatted_message(_result)
         ''

--- a/lib/minitest-bender/states/passing.rb
+++ b/lib/minitest-bender/states/passing.rb
@@ -4,7 +4,7 @@
 module MinitestBender
   module States
     class Passing < Base
-      COLOR = :green
+      COLOR = :green_500
       LABEL = 'PASSED'
       GROUP_LABEL = 'PASSING'
       ICON = '✔'

--- a/lib/minitest-bender/states/passing.rb
+++ b/lib/minitest-bender/states/passing.rb
@@ -1,9 +1,12 @@
+# coding: utf-8
+# frozen_string_literal: true
 module MinitestBender
   module States
     class Passing < Base
-      COLOR = :green_500
-      LABEL = 'PASSED'.freeze
-      GROUP_LABEL = 'PASSING'.freeze
+      COLOR = :green
+      LABEL = 'PASSED'
+      GROUP_LABEL = 'PASSING'
+      TAG = '✔'
 
       def formatted_message(_result)
         ''

--- a/lib/minitest-bender/states/passing.rb
+++ b/lib/minitest-bender/states/passing.rb
@@ -1,5 +1,6 @@
 # coding: utf-8
 # frozen_string_literal: true
+
 module MinitestBender
   module States
     class Passing < Base

--- a/lib/minitest-bender/states/raising.rb
+++ b/lib/minitest-bender/states/raising.rb
@@ -1,9 +1,12 @@
+# coding: utf-8
+# frozen_string_literal: true
 module MinitestBender
   module States
     class Raising < Base
-      COLOR = :amber_300
-      LABEL = 'RAISED'.freeze
-      GROUP_LABEL = 'ERRORS'.freeze
+      COLOR = :red # sorry... doesn't work on Windows
+      LABEL = 'RAISED'
+      GROUP_LABEL = 'ERRORS'
+      TAG = '⚡'
 
       def formatted_message(result)
         @formatted_message ||= colored(detailed_error_message(result))

--- a/lib/minitest-bender/states/raising.rb
+++ b/lib/minitest-bender/states/raising.rb
@@ -7,7 +7,7 @@ module MinitestBender
       COLOR = :red # sorry... doesn't work on Windows
       LABEL = 'RAISED'
       GROUP_LABEL = 'ERRORS'
-      TAG = '⚡'
+      ICON = '⚡'
 
       def formatted_message(result)
         @formatted_message ||= colored(detailed_error_message(result))

--- a/lib/minitest-bender/states/raising.rb
+++ b/lib/minitest-bender/states/raising.rb
@@ -1,5 +1,6 @@
 # coding: utf-8
 # frozen_string_literal: true
+
 module MinitestBender
   module States
     class Raising < Base

--- a/lib/minitest-bender/states/raising.rb
+++ b/lib/minitest-bender/states/raising.rb
@@ -7,7 +7,7 @@ module MinitestBender
       COLOR = :red # sorry... doesn't work on Windows
       LABEL = 'RAISED'
       GROUP_LABEL = 'ERRORS'
-      ICON = '⚡'
+      ICON = '💥'
 
       def formatted_message(result)
         @formatted_message ||= colored(detailed_error_message(result))

--- a/lib/minitest-bender/states/raising.rb
+++ b/lib/minitest-bender/states/raising.rb
@@ -4,7 +4,7 @@
 module MinitestBender
   module States
     class Raising < Base
-      COLOR = :red # sorry... doesn't work on Windows
+      COLOR = :amber_300
       LABEL = 'RAISED'
       GROUP_LABEL = 'ERRORS'
       ICON = '💥'
@@ -29,7 +29,7 @@ module MinitestBender
       def do_print_details(io, result, padding)
         io.puts "#{padding}#{colored(error_message(result))}"
         backtrace(result).each do |line|
-          io.puts "#{padding}#{Colorin.brown_400(line)}"
+          io.puts "#{padding}#{Colorizer.colorize(:brown_400, line)}"
         end
       end
 

--- a/lib/minitest-bender/states/skipped.rb
+++ b/lib/minitest-bender/states/skipped.rb
@@ -1,9 +1,12 @@
+# coding: utf-8
+# frozen_string_literal: true
 module MinitestBender
   module States
     class Skipped < Base
-      COLOR = :cyan_300
-      LABEL = 'SKIPPED'.freeze
-      GROUP_LABEL = 'SKIPS'.freeze
+      COLOR = :cyan
+      LABEL = 'SKIPPED'
+      GROUP_LABEL = 'SKIPS'
+      TAG = '/'
 
       def formatted_message(result)
         @formatted_message ||= colored(result.failures[0].message)

--- a/lib/minitest-bender/states/skipped.rb
+++ b/lib/minitest-bender/states/skipped.rb
@@ -7,7 +7,7 @@ module MinitestBender
       COLOR = :cyan
       LABEL = 'SKIPPED'
       GROUP_LABEL = 'SKIPS'
-      TAG = '/'
+      ICON = '/'
 
       def formatted_message(result)
         @formatted_message ||= colored(result.failures[0].message)

--- a/lib/minitest-bender/states/skipped.rb
+++ b/lib/minitest-bender/states/skipped.rb
@@ -1,5 +1,6 @@
 # coding: utf-8
 # frozen_string_literal: true
+
 module MinitestBender
   module States
     class Skipped < Base

--- a/lib/minitest-bender/states/skipped.rb
+++ b/lib/minitest-bender/states/skipped.rb
@@ -4,7 +4,7 @@
 module MinitestBender
   module States
     class Skipped < Base
-      COLOR = :cyan
+      COLOR = :cyan_300
       LABEL = 'SKIPPED'
       GROUP_LABEL = 'SKIPS'
       ICON = '/'

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -8,8 +8,9 @@ module Minitest
     attr_accessor :io, :options
     attr_reader :previous_context, :results, :results_by_context, :started_at
 
-    def self.enable!
+    def self.enable!(options = {})
       @@is_enabled = true
+      @@recorder = options.fetch(:recorder, :icons)
     end
 
     def self.enabled?
@@ -46,7 +47,13 @@ module Minitest
 
       if current_context != previous_context
         io.puts
-        io.print("#{result.header} ")
+
+        if verbose_recorder?
+          io.puts(result.header)
+        else
+          io.print("#{result.header} ")
+        end
+
         @previous_context = current_context
       end
 
@@ -54,7 +61,11 @@ module Minitest
 
       @slowness_podium_is_relevant = true if result.time > 0.01
 
-      io.print result.to_icon
+      if verbose_recorder?
+        io.puts result.line_to_report
+      else
+        io.print result.to_icon
+      end
     end
 
     def passed?
@@ -92,6 +103,10 @@ module Minitest
 
     def options_args
       options.fetch(:args, '(none)')
+    end
+
+    def verbose_recorder?
+      @@recorder == :verbose
     end
 
     def passed_without_skips?

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -6,7 +6,7 @@ module Minitest
     Colorizer = MinitestBender::Colorizer
 
     attr_accessor :io, :options
-    attr_reader :previous_context, :results, :started_at
+    attr_reader :previous_context, :results, :results_by_context, :started_at
 
     def self.enable!
       @@is_enabled = true
@@ -46,10 +46,11 @@ module Minitest
 
       if current_context != previous_context
         io.puts
-        io.print(result.header + ' ')
+        io.print("#{result.header} ")
         @previous_context = current_context
       end
-      (@results_by_context[current_context] ||= []) << result
+
+      (results_by_context[current_context] ||= []) << result
 
       @slowness_podium_is_relevant = true if result.time > 0.01
 
@@ -65,8 +66,7 @@ module Minitest
       io.puts
       print_divider(:white)
 
-      @results_by_context.keys.sort.each do |context|
-        results = @results_by_context[context]
+      results_by_context.sort.each do |context, results|
         io.puts
         io.puts(results.first.header)
         results.sort_by(&:sort_key).each { |result| io.puts result.line_to_report }

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -42,7 +42,7 @@ module Minitest
 
       @slowness_podium_is_relevant = true if result.time > 0.01
 
-      io.print result.compact
+      io.print result.to_icon
     end
 
     def passed?

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -5,17 +5,17 @@ module Minitest
   class Bender < AbstractReporter
     Colorizer = MinitestBender::Colorizer
 
+    @@reporter_options = {
+      recorder: :compact,
+      overview: :sorted
+    }
+
     attr_accessor :io, :options
     attr_reader :previous_context, :results, :results_by_context, :started_at
 
-    def self.enable!(options = {})
+    def self.enable!(reporter_options = {})
       @@is_enabled = true
-      @@recorder ||= :icons
-      @@overview ||= :sorted
-      @@recorder = options[:recorder] if options.include?(:recorder)
-      @@overview = options[:overview] if options.include?(:overview)
-      # Note: `--bender-verbose --bender-no-sorted-overview` and
-      # `--bender-no-sorted-overview --bender-verbose` must have same effect
+      @@reporter_options.merge!(reporter_options)
     end
 
     def self.enabled?
@@ -112,11 +112,11 @@ module Minitest
     end
 
     def verbose_recorder?
-      @@recorder == :verbose
+      @@reporter_options.fetch(:recorder) == :verbose
     end
 
     def sorted_overview_enabled?
-      @@overview == :sorted
+      @@reporter_options.fetch(:overview) == :sorted
     end
 
     def passed_without_skips?

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -23,6 +23,11 @@ module Minitest
     end
 
     def record(minitest_result)
+      # as we might already have some output from the test itself,
+      # make sure we see *all* of it before we report anything
+      STDOUT.flush
+      STDERR.flush
+
       result = MinitestBender.result_factory.create(minitest_result)
       results << result
 

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -151,8 +151,7 @@ module Minitest
     def print_sorted_overview
       io.puts(formatted_label(:white, 'SORTED OVERVIEW'))
       io.puts
-      @results_by_context.keys.sort.each do |context|
-        results = @results_by_context[context]
+      results_by_context.sort.each do |context, results|
         io.puts
         io.puts(results.first.header)
         results.sort_by(&:sort_key).each do |result|

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -3,6 +3,8 @@ require 'minitest_bender'
 
 module Minitest
   class Bender < AbstractReporter
+    Colorizer = MinitestBender::Colorizer
+
     attr_reader :io, :options, :previous_context, :results, :started_at
 
     def initialize(io, options = {})
@@ -17,8 +19,8 @@ module Minitest
     def start
       @started_at = Time.now
       io.puts
-      io.puts Colorin.white("Minitest started at #{started_at}")
-      io.puts Colorin.white("Options: #{options_args}")
+      io.puts Colorizer.colorize(:white, "Minitest started at #{started_at}")
+      io.puts Colorizer.colorize(:white, "Options: #{options_args}")
       io.puts
     end
 
@@ -108,7 +110,7 @@ module Minitest
     end
 
     def print_divider(color)
-      io.puts(Colorin.public_send(color, '  _______________________').bold)
+      io.puts(Colorizer.colorize(color, '  _______________________').bold)
       io.puts
     end
 
@@ -121,19 +123,19 @@ module Minitest
     def print_statistics
       total_tests = "#{test_count} tests"
       total_tests = total_tests.chop if test_count == 1
-      formatted_total_tests = Colorin.blue_a700(total_tests)
+      formatted_total_tests = Colorizer.colorize(:blue_a700, total_tests)
 
       total_assertions = "#{assertion_count} assertions"
       total_assertions = total_assertions.chop if assertion_count == 1
-      formatted_total_assertions = Colorin.purple_400(total_assertions)
+      formatted_total_assertions = Colorizer.colorize(:purple_400, total_assertions)
 
       auxiliary_verb = test_count == 1 ? 'was' : 'were'
 
       total_time = (Time.now - started_at).round(3)
-      formatted_total_time = Colorin.grey_700("#{total_time} seconds")
+      formatted_total_time = Colorizer.colorize(:grey_700, "#{total_time} seconds")
 
-      tests_rate = Colorin.grey_700("#{(test_count / total_time).round(4)} tests/s")
-      assertions_rate = Colorin.grey_700("#{(assertion_count / total_time).round(4)} assertions/s")
+      tests_rate = Colorizer.colorize(:grey_700, "#{(test_count / total_time).round(4)} tests/s")
+      assertions_rate = Colorizer.colorize(:grey_700, "#{(assertion_count / total_time).round(4)} assertions/s")
 
       io.puts "  #{formatted_total_tests} with #{formatted_total_assertions} #{auxiliary_verb} run in #{formatted_total_time} (#{tests_rate}, #{assertions_rate})"
     end
@@ -143,7 +145,7 @@ module Minitest
       final_divider_color = all_passed_color
 
       if passed_without_skips? && run_all_tests?
-        message = Colorin.public_send(all_passed_color, '  ALL TESTS PASS!  (^_^)/')
+        message = Colorizer.colorize(all_passed_color, '  ALL TESTS PASS!  (^_^)/')
       else
         messages = MinitestBender.states.values.map do |state|
           summary_message = state.summary_message(results)
@@ -170,7 +172,7 @@ module Minitest
     end
 
     def formatted_slowness_podium_label
-      "  #{Colorin.grey_700('SLOWNESS PODIUM').bold.underline}"
+      "  #{Colorizer.colorize(:grey_700, 'SLOWNESS PODIUM').bold.underline}"
     end
   end
 end

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -58,7 +58,7 @@ module Minitest
         results = @results_by_context[context]
         io.puts
         io.puts(results.first.header)
-        results.sort_by(&:rank).each { |result| io.puts result.line_to_report }
+        results.sort_by(&:sort_key).each { |result| io.puts result.line_to_report }
       end
 
       io.puts

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -10,6 +10,7 @@ module Minitest
       @options = options
       @previous_context = nil
       @results = []
+      @results_by_context = {}
       @slowness_podium_is_relevant = false
     end
 
@@ -29,13 +30,14 @@ module Minitest
 
       if current_context != previous_context
         io.puts
-        io.puts(result.header)
+        io.print(result.header + ' ')
         @previous_context = current_context
       end
+      (@results_by_context[current_context] ||= []) << result
 
       @slowness_podium_is_relevant = true if result.time > 0.01
 
-      io.puts result.line_to_report
+      io.print result.compact
     end
 
     def passed?
@@ -43,6 +45,17 @@ module Minitest
     end
 
     def report
+      io.puts
+      io.puts
+      print_divider(:white)
+
+      @results_by_context.keys.sort.each do |context|
+        results = @results_by_context[context]
+        io.puts
+        io.puts(results.first.header)
+        results.sort_by(&:rank).each { |result| io.puts result.line_to_report }
+      end
+
       io.puts
       print_divider(:white)
 

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -29,7 +29,6 @@ module Minitest
       @results = []
       @results_by_context = {}
       @slowness_podium_is_relevant = false
-      @state_counters = Hash.new { |state| @state_counters[state] = 0 }
     end
 
     def start
@@ -172,13 +171,7 @@ module Minitest
 
     def print_verbose_result(result)
       io.puts result.line_to_report
-      unless result.passed?
-        MinitestBender.states.values.each do |state|
-          next unless result.state?(state)
-
-          state.print_detail(io, @state_counters[state] += 1, result)
-        end
-      end
+      result.state.print_detail(io, result) unless result.passed?
     end
 
     def print_statistics

--- a/lib/minitest/bender_plugin.rb
+++ b/lib/minitest/bender_plugin.rb
@@ -8,15 +8,15 @@ module Minitest
   end
 
   def self.plugin_bender_options(opts, _options)
-    opts.on '--bender', 'Use Minitest::Bender test reporter' do
+    opts.on '--bender', 'Enable Bender: the coolest CLI reporter.' do
       Bender.enable!
     end
-    opts.on '--bender-verbose',
-            'Bender report details of test failure as they happen' do
-      Bender.enable!({ recorder: :verbose })
+
+    opts.on '--bender-recorder=RECORDER', 'Bender: choose how test results are printed as the suite runs. (compact | verbose)' do |r|
+      Bender.enable!({ recorder: r.to_sym })
     end
-    opts.on '--bender-no-sorted-overview',
-            'Bender will not show the sorted overview section' do
+
+    opts.on('--bender-no-overview', 'Bender: skip the overview of sorted results.') do
       Bender.enable!({ overview: :none })
     end
   end

--- a/lib/minitest/bender_plugin.rb
+++ b/lib/minitest/bender_plugin.rb
@@ -11,5 +11,9 @@ module Minitest
     opts.on '--bender', 'Use Minitest::Bender test reporter' do
       Bender.enable!
     end
+
+    opts.on '--bender-verbose', 'Use Minitest::Bender test reporter and run each test verbosely' do
+      Bender.enable!({ recorder: :verbose })
+    end
   end
 end

--- a/lib/minitest/bender_plugin.rb
+++ b/lib/minitest/bender_plugin.rb
@@ -11,5 +11,13 @@ module Minitest
     opts.on '--bender', 'Use Minitest::Bender test reporter' do
       Bender.enable!
     end
+    opts.on '--bender-verbose',
+            'Bender report details of test failure as they happen' do
+      Bender.verbose!
+    end
+    opts.on '--bender-no-sorted-overview',
+            'Bender will not show the sorted overview section' do
+      Bender.no_sorted_overview!
+    end
   end
 end

--- a/lib/minitest_bender.rb
+++ b/lib/minitest_bender.rb
@@ -2,6 +2,8 @@ require 'colorin'
 
 require 'minitest-bender/version'
 
+require 'minitest-bender/colorizer'
+
 require 'minitest-bender/states/base'
 require 'minitest-bender/states/passing'
 require 'minitest-bender/states/skipped'


### PR DESCRIPTION
Now the meat of it ;-)

Minitest has a strong stance on randomizing the order of execution of tests.
That's all fine for the robustness of the testing itself, but when it comes to reading the report of the tests, this randomness can be very frustrating at times.

So the idea is to only produce some minimal output while the reporting progresses, and to make a more useful report at the end, first sorting the contexts, then within each context, sorting the tests themselves. You can then see at a glance where the failures and errors are located, and this alone can often be telling about the root cause.

I didn't sort the last FAILURES and ERRORS sections, because, well, you'd have to fix all of them anyway, right? So the order there doesn't matter as much.

Finally, there are some changes in the "fanciness" of the output: the colors are the more standard green/red/yellow now because the ones with the weights (or amber_300!) didn't work on Windows. To make up for that, I added some nice Unicode characters ;-)
