### PR TITLE
Avoid secondary error while producing the TEST=... info for a re-run.

### DIFF
--- a/lib/minitest-bender/states/raising.rb
+++ b/lib/minitest-bender/states/raising.rb
@@ -20,8 +20,14 @@ module MinitestBender
       end
 
       def test_location(result)
-        backtrace_line = backtrace(result).select { |line| line =~ /\/test\/|\/spec\// }.last
-        Utils.relative_path(backtrace_line).split(':').first
+        backtrace_line = backtrace(result).select do |line|
+          File.dirname(line) == '.' || line =~ %r{(^|/)(test|spec)/}
+        end.last
+        if backtrace_line
+          Utils.relative_path(backtrace_line).split(':').first
+        else
+          "(test location can't be deduced from backtrace)"
+        end
       end
 
       private


### PR DESCRIPTION
The "normal" use case works fine: when you run your test suite through
`rake test` and the usual Rake::TestTask, the file paths of the test
files end up being absolute paths.

When you run the test directly, with:

    ruby spec/my_spec.rb

the path ends up being a relative one and this triggers the following
error:

    .../minitest-bender/lib/minitest-bender/utils.rb:4:in `relative_path': undefined method `gsub' for nil:NilClass (NoMethodError)

This is because the regexp trying to identify the sources in the
'/spec/' or '/test/' directories fails for a 'spec/...' input.

We fix this and also cope with the case of going directly in the
directory containing the test source and running it from there
(e.g. cd spec; ruby my_spec.rb).

If the path to the test source really can't be identified, we say
so instead of failing with a secondary error.