### PR TITLE
Sorted overview fixes

### DIFF
--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -18,17 +18,31 @@ module MinitestBender
         @execution_order = @state.incr
       end
 
-      def context
-        @context ||=
+      def context_members
+        @context_members ||=
           if minitest_result.respond_to?(:klass) # minitest >= 5.11
             minitest_result.klass
           else
             minitest_result.class.name
-          end.gsub('::', CLASS_SEP)
+          end.split('::')
       end
 
-      def header
-        Colorizer.colorize(:white, "• #{context}").bold
+      def context(i = nil, j = nil)
+        if i && j
+          context_members[i..j].join(CLASS_SEP)
+        else
+          @context ||= context_members.join(CLASS_SEP)
+        end
+      end
+
+      def header(i = 0, j = -1)
+        prefix = '• '
+        if j == -1
+          prefix = CLASS_SEP if i > 0
+          Colorizer.colorize(:white, prefix + context(i, j))
+        else
+          Colorizer.colorize(:white, prefix + context(i, j)).bold
+        end
       end
 
       def to_icon

--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -37,6 +37,10 @@ module MinitestBender
         state.colored_icon
       end
 
+      def line_to_report
+        content_to_report.join(' ')
+      end
+
       def details_header(number)
         "    #{number}#{formatted_name_with_context}"
       end

--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -10,7 +10,8 @@ module MinitestBender
       attr_reader :state, :execution_order
 
       CLASS_SEP = ' ▸ '
-      NAME_SEP =  ' ◆ '
+      NAME_SEP =  ' ♦ '
+      HEADER_PREFIX = '• '
 
       def initialize(minitest_result)
         @minitest_result = minitest_result
@@ -18,31 +19,18 @@ module MinitestBender
         @execution_order = @state.incr
       end
 
-      def context_members
-        @context_members ||=
+      def context
+        @context ||=
           if minitest_result.respond_to?(:klass) # minitest >= 5.11
             minitest_result.klass
           else
             minitest_result.class.name
-          end.split('::')
+          end.split('::').join(CLASS_SEP)
       end
 
-      def context(i = nil, j = nil)
-        if i && j
-          context_members[i..j].join(CLASS_SEP)
-        else
-          @context ||= context_members.join(CLASS_SEP)
-        end
-      end
-
-      def header(i = 0, j = -1)
-        prefix = '• '
-        if j == -1
-          prefix = CLASS_SEP if i > 0
-          Colorizer.colorize(:white, prefix + context(i, j))
-        else
-          Colorizer.colorize(:white, prefix + context(i, j)).bold
-        end
+      def header(msg = nil)
+        msg ||= Colorizer.colorize(:white, context).bold
+        Colorizer.colorize(:white, HEADER_PREFIX).bold + msg
       end
 
       def to_icon

--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -9,8 +9,9 @@ module MinitestBender
       def_delegators :@minitest_result, :passed?, :skipped?, :assertions, :failures, :time
       attr_reader :state, :execution_order
 
-      CLASS_SEP = ' ▸ '
-      NAME_SEP =  ' ♦ '
+      CLASS_SEPARATOR = '::'
+      CONTEXT_SEPARATOR = ' ▸ '
+      NAME_PREFIX = '♦ '
       HEADER_PREFIX = '• '
 
       def initialize(minitest_result)
@@ -20,12 +21,11 @@ module MinitestBender
       end
 
       def context
-        @context ||=
-          if minitest_result.respond_to?(:klass) # minitest >= 5.11
-            minitest_result.klass
-          else
-            minitest_result.class.name
-          end.split('::').join(CLASS_SEP)
+        @context ||= class_name.split(class_separator).join(context_separator)
+      end
+
+      def context_separator
+        CONTEXT_SEPARATOR
       end
 
       def header(msg = nil)
@@ -38,7 +38,7 @@ module MinitestBender
       end
 
       def details_header(number)
-        "    #{number}#{Colorizer.colorize(:white, context)}#{NAME_SEP}#{name}"
+        "    #{number}#{formatted_name_with_context}"
       end
 
       def rerun_line(padding)
@@ -51,12 +51,32 @@ module MinitestBender
       end
 
       def line_for_time_ranking
-        "#{formatted_time} #{Colorizer.colorize(:white, context)}#{NAME_SEP}#{name}"
+        "#{formatted_time} #{formatted_name_with_context}"
       end
 
       private
 
       attr_reader :minitest_result
+
+      def class_name
+        if minitest_result.respond_to?(:klass) # minitest >= 5.11
+          minitest_result.klass
+        else
+          minitest_result.class.name
+        end
+      end
+
+      def class_separator
+        CLASS_SEPARATOR
+      end
+
+      def name_prefix
+        NAME_PREFIX
+      end
+
+      def formatted_name_with_context
+        "#{Colorizer.colorize(:white, context)} #{name_prefix}#{name}"
+      end
 
       def formatted_label
         "    #{state.formatted_label}"

--- a/lib/minitest-bender/results/expectation.rb
+++ b/lib/minitest-bender/results/expectation.rb
@@ -7,6 +7,10 @@ module MinitestBender
         @name = name
       end
 
+      def content_to_report
+        ["#{formatted_label}#{formatted_time} #{formatted_number}", "#{name} #{formatted_message}"]
+      end
+
       def line_to_report
         "#{formatted_label}#{formatted_time} #{formatted_number} #{name} #{formatted_message}"
       end

--- a/lib/minitest-bender/results/expectation.rb
+++ b/lib/minitest-bender/results/expectation.rb
@@ -11,10 +11,6 @@ module MinitestBender
         ["#{formatted_label}#{formatted_time} #{formatted_number}", "#{name} #{formatted_message}"]
       end
 
-      def line_to_report
-        "#{formatted_label}#{formatted_time} #{formatted_number} #{name} #{formatted_message}"
-      end
-
       def sort_key
         @sort_key ||= number.to_i
       end

--- a/lib/minitest-bender/results/test.rb
+++ b/lib/minitest-bender/results/test.rb
@@ -6,7 +6,7 @@ module MinitestBender
         @raw_name = raw_name
       end
 
-      def context(*)
+      def context
         super.gsub(/^Test|Test$/, '')
       end
 

--- a/lib/minitest-bender/results/test.rb
+++ b/lib/minitest-bender/results/test.rb
@@ -6,7 +6,7 @@ module MinitestBender
         @raw_name = raw_name
       end
 
-      def context
+      def context(*)
         super.gsub(/^Test|Test$/, '')
       end
 

--- a/lib/minitest-bender/results/test.rb
+++ b/lib/minitest-bender/results/test.rb
@@ -10,6 +10,10 @@ module MinitestBender
         super.gsub(/^Test|Test$/, '')
       end
 
+      def content_to_report
+        ["#{formatted_label}#{formatted_time}", "#{name} #{formatted_message}"]
+      end
+
       def line_to_report
         "#{formatted_label}#{formatted_time} #{name} #{formatted_message}"
       end

--- a/lib/minitest-bender/results/test.rb
+++ b/lib/minitest-bender/results/test.rb
@@ -14,10 +14,6 @@ module MinitestBender
         ["#{formatted_label}#{formatted_time}", "#{name} #{formatted_message}"]
       end
 
-      def line_to_report
-        "#{formatted_label}#{formatted_time} #{name} #{formatted_message}"
-      end
-
       def sort_key
         raw_name
       end

--- a/lib/minitest-bender/states/failing.rb
+++ b/lib/minitest-bender/states/failing.rb
@@ -10,7 +10,7 @@ module MinitestBender
       ICON = '✖'
 
       def formatted_message(result)
-        @formatted_message = colored(location(result))
+        colored(location(result))
       end
 
       def summary_message(results)

--- a/lib/minitest-bender/states/failing.rb
+++ b/lib/minitest-bender/states/failing.rb
@@ -10,7 +10,7 @@ module MinitestBender
       ICON = '✖'
 
       def formatted_message(result)
-        @formatted_message ||= colored(location(result))
+        @formatted_message = colored(location(result))
       end
 
       def summary_message(results)

--- a/lib/minitest-bender/states/raising.rb
+++ b/lib/minitest-bender/states/raising.rb
@@ -10,7 +10,7 @@ module MinitestBender
       ICON = '💥'
 
       def formatted_message(result)
-        @formatted_message = colored(detailed_error_message(result))
+        colored(detailed_error_message(result))
       end
 
       def summary_message(results)

--- a/lib/minitest-bender/states/raising.rb
+++ b/lib/minitest-bender/states/raising.rb
@@ -10,7 +10,7 @@ module MinitestBender
       ICON = '💥'
 
       def formatted_message(result)
-        @formatted_message ||= colored(detailed_error_message(result))
+        @formatted_message = colored(detailed_error_message(result))
       end
 
       def summary_message(results)

--- a/lib/minitest-bender/states/skipped.rb
+++ b/lib/minitest-bender/states/skipped.rb
@@ -10,7 +10,7 @@ module MinitestBender
       ICON = '/'
 
       def formatted_message(result)
-        @formatted_message = colored(result.failures[0].message)
+        colored(result.failures[0].message)
       end
 
       def summary_message(results)

--- a/lib/minitest-bender/states/skipped.rb
+++ b/lib/minitest-bender/states/skipped.rb
@@ -10,7 +10,7 @@ module MinitestBender
       ICON = '/'
 
       def formatted_message(result)
-        @formatted_message ||= colored(result.failures[0].message)
+        @formatted_message = colored(result.failures[0].message)
       end
 
       def summary_message(results)

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -179,22 +179,26 @@ module Minitest
       previous_context = []
       results_by_context.sort.each do |context, results|
         io.puts
-        context = results.first.context_members
-        i = first_difference_index(previous_context, context)
-        io.print(results.first.header(0, i - 1)) if i > 0
-        io.puts(results.first.header(i, -1))
+        previous_context = print_header(results.first, previous_context)
         results.sort_by(&:sort_key).each do |result|
           io.puts result.line_to_report
         end
-        previous_context = context
       end
       io.puts
       print_divider(:white)
     end
 
-    def first_difference_index(a, b)
-      a.each_with_index { |a_elt, i| return i if b[i] != a_elt }
-      a.size
+    def print_header(result, previous_context)
+      context = result.context_members
+      i = first_difference_index(previous_context.each_with_index, context)
+      io.print(result.header(0, i - 1)) if i > 0
+      io.puts(result.header(i, -1))
+      context
+    end
+
+    def first_difference_index(enum, other)
+      enum.each { |elt, i| return i if other[i] != elt }
+      enum.size
     end
 
     def print_details

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -180,9 +180,9 @@ module Minitest
       results_by_context.sort.each do |context, results|
         io.puts
         previous_context = print_header(results.first, previous_context)
-        previous_message = ''
+        previous_words = []
         results.sort_by(&:sort_key).each do |result|
-          previous_message = print_result_line(result, previous_message)
+          previous_words = print_result_line(result, previous_words)
         end
       end
       io.puts
@@ -191,23 +191,26 @@ module Minitest
 
     def print_header(result, previous_context)
       context = result.context_members
-      i = first_difference_index(previous_context.each_with_index, context)
+      i = first_difference_index(previous_context, context)
       io.print(result.header(0, i - 1)) if i > 0
       io.puts(result.header(i, -1))
       context
     end
 
-    def print_result_line(result, previous_message)
+    def print_result_line(result, previous_words)
       prefix, message = result.content_to_report
-      i = first_difference_index(previous_message.each_char.with_index, message)
-      io.print("#{prefix} " + Colorizer.colorize(:white, message[0...i]).bold)
-      io.puts(Colorizer.colorize(:white, message[i..-1] || ''))
-      message
+      words = message.split(' ')
+      i = first_difference_index(previous_words, words)
+      old = words[0...i].join(' ')
+      new = words[i..-1].join(' ')
+      new = " #{new}" unless old.empty?
+      io.puts("#{prefix} " + Colorizer.colorize(:white, old).bold + Colorizer.colorize(:white, new))
+      words
     end
 
-    def first_difference_index(enum, other)
-      enum.each { |elt, i| return i if other[i] != elt }
-      enum.size
+    def first_difference_index(base, other)
+      base.each_with_index { |elt, i| return i if other[i] != elt }
+      base.size
     end
 
     def print_details

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -180,8 +180,9 @@ module Minitest
       results_by_context.sort.each do |context, results|
         io.puts
         previous_context = print_header(results.first, previous_context)
+        previous_message = ''
         results.sort_by(&:sort_key).each do |result|
-          io.puts result.line_to_report
+          previous_message = print_result_line(result, previous_message)
         end
       end
       io.puts
@@ -194,6 +195,14 @@ module Minitest
       io.print(result.header(0, i - 1)) if i > 0
       io.puts(result.header(i, -1))
       context
+    end
+
+    def print_result_line(result, previous_message)
+      prefix, message = result.content_to_report
+      i = first_difference_index(previous_message.each_char.with_index, message)
+      io.print("#{prefix} " + Colorizer.colorize(:white, message[0...i]).bold)
+      io.puts(Colorizer.colorize(:white, message[i..-1] || ''))
+      message
     end
 
     def first_difference_index(enum, other)

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -176,10 +176,10 @@ module Minitest
     def print_sorted_overview
       io.puts(formatted_label(:white, 'SORTED OVERVIEW'))
       io.puts
-      previous_context = []
+      previous_split_context = []
       results_by_context.sort.each do |context, results|
         io.puts
-        previous_context = print_header(results.first, previous_context)
+        previous_split_context = print_header(results.first, previous_split_context)
         previous_words = []
         results.sort_by(&:sort_key).each do |result|
           previous_words = print_result_line(result, previous_words)
@@ -189,14 +189,14 @@ module Minitest
       print_divider(:white)
     end
 
-    def print_header(result, previous_context)
-      class_sep = MinitestBender::Results::Base::CLASS_SEP
-      context = result.context.split(class_sep)
-      old, new = split_old_new(previous_context, context, class_sep)
+    def print_header(result, previous_split_context)
+      context_separator = result.context_separator
+      split_context = result.context.split(context_separator)
+      old, new = split_old_new(previous_split_context, split_context, context_separator)
       old = Colorizer.colorize(:white, old)
       new = Colorizer.colorize(:white, new).bold
       io.puts(result.header("#{old}#{new}"))
-      context
+      split_context
     end
 
     def print_result_line(result, previous_words)

--- a/lib/minitest/bender.rb
+++ b/lib/minitest/bender.rb
@@ -176,15 +176,25 @@ module Minitest
     def print_sorted_overview
       io.puts(formatted_label(:white, 'SORTED OVERVIEW'))
       io.puts
+      previous_context = []
       results_by_context.sort.each do |context, results|
         io.puts
-        io.puts(results.first.header)
+        context = results.first.context_members
+        i = first_difference_index(previous_context, context)
+        io.print(results.first.header(0, i - 1)) if i > 0
+        io.puts(results.first.header(i, -1))
         results.sort_by(&:sort_key).each do |result|
           io.puts result.line_to_report
         end
+        previous_context = context
       end
       io.puts
       print_divider(:white)
+    end
+
+    def first_difference_index(a, b)
+      a.each_with_index { |a_elt, i| return i if b[i] != a_elt }
+      a.size
     end
 
     def print_details


### PR DESCRIPTION
I somehow managed to not notice until now that the line numbers reported for failures and errors in the new sorted overview were wrong. They were all the same file and line. Not so surprising after looking in the code, as these values were cached. Possibly justified in earlier versions, but now that we use `formatted_message` for different results, there's no point caching that.

While I was at it, I implemented the last improvement I had in mind for the sorted overview, which is a visual hint about the structure of the tests, by highlighting what's different from one row to the next.

Screenshots are always nice :-)

Current state on master, showing both the defect and the "flat" list:

![image](https://user-images.githubusercontent.com/153279/83955266-3f894700-a851-11ea-97e2-9ef71bf67e9c.png)

With the changes on this branch:

![image](https://user-images.githubusercontent.com/153279/83955270-5b8ce880-a851-11ea-80ea-fcdb51bf32a6.png)

 File and line numbers are now correct for each result + visual hint for the differences from one result to the next. 