### PR TITLE
Fix location reporting (again)

### DIFF
--- a/lib/minitest-bender/result_factory.rb
+++ b/lib/minitest-bender/result_factory.rb
@@ -26,6 +26,11 @@ module MinitestBender
     end
 
     def parsed_name(minitest_result)
+      if minitest_result.name.is_a?(Class)
+        # something went wrong inside minitest (infinite loop?)
+        raise minitest_result.failures[0].error
+      end
+
       minitest_result.name.match(RESULT_NAME_REGEXP)
     end
   end

--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -58,6 +58,10 @@ module MinitestBender
         "#{formatted_time} #{formatted_name_with_context}"
       end
 
+      def file_path
+        source_location[0]
+      end
+
       private
 
       attr_reader :minitest_result
@@ -67,6 +71,15 @@ module MinitestBender
           minitest_result.klass
         else
           minitest_result.class.name
+        end
+      end
+
+      # credit where credit is due: minitest-line
+      def source_location
+        if minitest_result.respond_to?(:source_location) # minitest >= 5.11
+          minitest_result.source_location
+        else
+          minitest_result.method(minitest_result.name).source_location
         end
       end
 

--- a/lib/minitest-bender/results/base.rb
+++ b/lib/minitest-bender/results/base.rb
@@ -83,7 +83,9 @@ module MinitestBender
       end
 
       def rerun_command
-        relative_location = state.test_location(self).split(':').first
+        return unless (relative_location = state.test_location(self))
+
+        relative_location = relative_location.split(':').first
         "rake TEST=#{relative_location} TESTOPTS=\"--name=#{name_for_rerun_command}\""
       end
     end

--- a/lib/minitest-bender/states/raising.rb
+++ b/lib/minitest-bender/states/raising.rb
@@ -50,7 +50,8 @@ module MinitestBender
       end
 
       def backtrace(result)
-        result.failures[0].backtrace
+        # Minitest::UnexpectedError: SystemStackError: stack level too deep
+        result.failures[0].backtrace || ['']
       end
     end
   end

--- a/lib/minitest-bender/states/raising.rb
+++ b/lib/minitest-bender/states/raising.rb
@@ -26,14 +26,7 @@ module MinitestBender
       end
 
       def test_location(result)
-        backtrace_line = user_backtrace(result).select do |line|
-          File.dirname(line) == '.' || line =~ %r{(^|/)(test|spec)/}
-        end.last
-        if backtrace_line
-          Utils.relative_path(backtrace_line).split(':').first
-        else
-          "(test location can't be deduced from backtrace)"
-        end
+        Utils.relative_path(result.file_path)
       end
 
       private
@@ -68,8 +61,7 @@ module MinitestBender
       end
 
       def full_backtrace(result)
-        # Minitest::UnexpectedError: SystemStackError: stack level too deep
-        result.failures[0].backtrace || ['']
+        result.failures[0].backtrace || []
       end
     end
   end


### PR DESCRIPTION
This is just a quick fix to avoid having Bender itself fail with a backtrace.

But actually we don't get the location itself, the approach to retrieve it can certainly be done differently. For example, even in my corner-case failure involving a `SystemStackError`,
the `minitest-line` extension was able to correctly get its file and line number. 